### PR TITLE
Fix variable-length array warning in clang

### DIFF
--- a/compiler/codegen/ELFGenerator.cpp
+++ b/compiler/codegen/ELFGenerator.cpp
@@ -339,9 +339,9 @@ void
 TR::ELFGenerator::writeELFSymbolsToFile(::FILE *fp)
 {
     
-    ELFSymbol * elfSym = static_cast<ELFSymbol*>(_rawAllocator.allocate(sizeof(ELFSymbol)));
-    char ELFSymbolNames[_totalELFSymbolNamesLength];
-    
+    ELFSymbol *elfSym = static_cast<ELFSymbol*>(_rawAllocator.allocate(sizeof(ELFSymbol)));
+    char *ELFSymbolNames = static_cast<char*>(_rawAllocator.allocate(_totalELFSymbolNamesLength));
+
     /* Writing the UNDEF symbol*/
     elfSym->st_name = 0;
     elfSym->st_info = 0;
@@ -387,6 +387,7 @@ TR::ELFGenerator::writeELFSymbolsToFile(::FILE *fp)
     /* Finally, write the symbol names to file */
     fwrite(ELFSymbolNames, sizeof(uint8_t), _totalELFSymbolNamesLength, fp);
 
+    _rawAllocator.deallocate(ELFSymbolNames);
     _rawAllocator.deallocate(elfSym);
 }
 


### PR DESCRIPTION
The _totalELFSymbolNamesLength is a dynamic quantity, and creating an array of that length in C++ causes a warning-as-error with Clang 18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced memory management for symbol names in ELF file generation.
	- Ensured proper deallocation of dynamically allocated memory.
	- Maintained existing functionality without any changes to the ELF file emission process.
- **Style**
	- Minor code formatting adjustments for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->