### PR TITLE
Check if mul can overflow during BNDCHK simplification

### DIFF
--- a/compiler/optimizer/OMRSimplifierHandlers.cpp
+++ b/compiler/optimizer/OMRSimplifierHandlers.cpp
@@ -17246,8 +17246,10 @@ TR::Node *bndchkSimplifier(TR::Node * node, TR::Block * block, TR::Simplifier * 
          }
       }
    else if (boundChild->getOpCode().isLoadConst() &&
-            (indexChild->getOpCode().isMul() && !isNodeMulHigh(indexChild) &&
-                 indexChild->getSecondChild()->getOpCode().isLoadConst()))
+            (indexChild->getOpCode().isMul() &&
+               !isNodeMulHigh(indexChild) &&
+               indexChild->cannotOverflow() &&
+               indexChild->getSecondChild()->getOpCode().isLoadConst()))
       {
       int32_t k1 = boundChild->getInt();
       int32_t k2 = indexChild->getSecondChild()->getInt();
@@ -17581,8 +17583,10 @@ TR::Node *bndchkwithspinechkSimplifier(TR::Node * node, TR::Block * block, TR::S
          }
       }
    else if (boundChild->getOpCode().isLoadConst() &&
-            (indexChild->getOpCode().isMul() && !isNodeMulHigh(indexChild) &&
-             indexChild->getSecondChild()->getOpCode().isLoadConst()))
+            (indexChild->getOpCode().isMul() &&
+               !isNodeMulHigh(indexChild) &&
+               indexChild->cannotOverflow() &&
+               indexChild->getSecondChild()->getOpCode().isLoadConst()))
       {
       int32_t k1 = boundChild->getInt();
       int32_t k2 = indexChild->getSecondChild()->getInt();


### PR DESCRIPTION
For BNDCHK nodes where the first child is a constant and the second child is a multiplication operation, with the multiplier child being a constant, it was getting simplified such that the bound value was being divided by the multiplier. While this is a valid simplification that eliminates the multiplication operation, it would only be valid if we could guarantee that the multiplication was not going to overflow. This change ensures that this simplification is performed only for mul operation nodes that have been marked as cannotOverflow.