### PR TITLE
Add structural analysis by using given CFG and add _hasBackEdges flag…

### DIFF
--- a/compiler/infra/OMRCfg.hpp
+++ b/compiler/infra/OMRCfg.hpp
@@ -137,6 +137,7 @@ class CFG
       _calledFrequency = 0;
       _initialBlockFrequency = -1;
       _edgeProbabilities = NULL;
+      _hasBackEdges = false;
    }
 
    TR::CFG * self();
@@ -360,6 +361,9 @@ class CFG
 
    static const char *blockFrequencyNames[];
 
+   void setHasBackEdges() { _hasBackEdges = true; }
+   bool hasBackEdges() { return _hasBackEdges; }
+
 protected:
    TR::Compilation *_compilation;
    TR::ResolvedMethodSymbol *_method;
@@ -379,6 +383,7 @@ protected:
    bool _ignoreUnreachableBlocks;
    bool _removingUnreachableBlocks;
 
+   bool _hasBackEdges;
 
    TR::CFGNode **_forwardTraversalOrder;
    int32_t _forwardTraversalLength;

--- a/compiler/optimizer/Dominators.hpp
+++ b/compiler/optimizer/Dominators.hpp
@@ -53,11 +53,14 @@ class TR_Dominators
    TR_ALLOC(TR_Memory::Dominators)
 
    TR_Dominators(TR::Compilation *, bool post = false);
+   TR_Dominators(TR::Compilation *, TR::CFG* cfg, bool acceptUnreachableBlocks = true, bool post = false);
    TR::Block       *getDominator(TR::Block *);
    int             dominates(TR::Block *block, TR::Block *other);
 
    TR::Compilation * comp()         { return _compilation; }
    bool trace() { return _trace; }
+   bool isValid() { return _isValid; }
+   bool hasUnreachableBlocks() { return _hasUnreachableBlocks; }
 
    protected:
 
@@ -113,6 +116,8 @@ class TR_Dominators
       int32_t parent;
       };
 
+   void    construct(TR::CFG* cfg, bool post, bool acceptUnreachableBlocks = true);
+
    BBInfo& getInfo(int32_t index) {return _info[index];}
    int32_t blockNumber(int32_t index) {return _info[index]._block->getNumber();}
 
@@ -133,6 +138,7 @@ class TR_Dominators
    int32_t         _numNodes;
    int32_t         _topDfNum;
    vcount_t        _visitCount;
+   bool            _hasUnreachableBlocks;
 
    protected:
    TR::CFG *         _cfg;

--- a/compiler/optimizer/StructuralAnalysis.hpp
+++ b/compiler/optimizer/StructuralAnalysis.hpp
@@ -52,6 +52,7 @@ class TR_RegionAnalysis
 
    static TR_Structure *getRegions(TR::Compilation *);
    static TR_Structure *getRegions(TR::Compilation *, TR::ResolvedMethodSymbol *);
+   static TR_Structure *getRegions(TR::Compilation *, TR::CFG *, bool acceptUnreachableBlocks = true);
 
    friend class TR_Debug;
 
@@ -121,6 +122,8 @@ class TR_RegionAnalysis
    bool _trace;
    bool _useNew;
    void createLeafStructures(TR::CFG *cfg, TR::Region &region);
+
+   static TR_Structure *getRegionsImpl(TR::Compilation *comp, TR_Dominators& dominators, TR::CFG* cfg);
 
    TR_Structure       *findRegions(TR::Region &region);
    TR_RegionStructure *findNaturalLoop(StructInfo &node,


### PR DESCRIPTION
… when generating CFG

This is a part of the BenefitInliner contribution.

* Dominators.hpp, Dominators.cpp, StructuralAnalysis.hpp, StructuralAnalysis.cpp: add structural analysis by using given CFG.
* OMRCfg.hpp: add _hasBackEdges flag to mark having loop in the CFG.